### PR TITLE
Add translation and search endpoints

### DIFF
--- a/integreat_chat/chatanswers/services/language.py
+++ b/integreat_chat/chatanswers/services/language.py
@@ -1,0 +1,50 @@
+"""
+A service to detect languages and translate messages
+"""
+
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.output_parsers import StrOutputParser
+from langchain_community.llms import Ollama
+
+#from langchain.runnables.base import RunnableLambda
+from langchain_core.runnables import RunnableLambda
+
+from django.conf import settings
+
+class LanguageService:
+    """
+    Service class that enables searching for Integreat content
+    """
+    def __init__(self):
+        """
+        
+        """
+
+    def classify_language(self, estimated_lang, message):
+        """
+        Check if a message fits the estimated language. Return another language tag, if it does not fit.
+        """
+        prompt = (
+            f'Can the following message be in the language with the language tag "{estimated_lang}"? '
+            f'If yes, answer with "{estimated_lang}". If no, return a single most likely BCP47 language '
+            f'tag for the message.\n\nMessage: {message}'
+        )
+        parser = StrOutputParser()
+        llm = Ollama(model=settings.LANGUAGE_CLASSIFICATIONH_MODEL, base_url=settings.OLLAMA_BASE_PATH)
+        answer = parser.invoke(llm.invoke(prompt))
+        if answer.startswith(estimated_lang):
+            return estimated_lang
+        return answer.split("-")[0]
+
+    def translate_message(self, source_language, target_language, message):
+        """
+        Translate a message from source to target language
+        """
+        prompt = (
+            f'The following message is written in the language with language tag "{source_language}". '
+            f'Translate the message to the language with the language tag {target_language}. '
+            f'Return only the translated message with no additional words.\n\nMessage: {message}'
+        )
+        parser = StrOutputParser()
+        llm = Ollama(model=settings.TRANSLATION_MODEL, base_url=settings.OLLAMA_BASE_PATH)
+        return parser.invoke(llm.invoke(prompt))

--- a/integreat_chat/chatanswers/services/search.py
+++ b/integreat_chat/chatanswers/services/search.py
@@ -1,0 +1,64 @@
+"""
+A service to search for documents
+"""
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.output_parsers import StrOutputParser
+from langchain_community.llms import Ollama
+from langchain_milvus.vectorstores import Milvus
+
+#from langchain.runnables.base import RunnableLambda
+from langchain_core.runnables import RunnableLambda
+
+from django.conf import settings
+
+
+class SearchService:
+    """
+    Service class that enables searching for Integreat content
+    """
+    _instance = None
+
+    @staticmethod
+    def get_instance(region, language):
+        if SearchService._instance is None:
+            SearchService._instance = SearchService(region, language)
+        return SearchService._instance
+
+    def __init__(self, region, language):
+        self.language = language
+        self.llm_model_name = settings.RAG_MODEL
+
+        self.vdb_host = settings.VDB_HOST
+        self.vdb_port = settings.VDB_PORT
+        self.vdb_collection = f"collection_ig_{region}_{language}"
+        self.vdb = self.load_vdb(self.vdb_host, self.vdb_port,
+                                 self.vdb_collection, settings.EMBEDDINGS)
+
+    def load_vdb(self, URI, port, collection, embedding_model):
+        vdb = Milvus(
+                embedding_model,
+                connection_args={"host": URI, "port": port},
+                collection_name=collection)
+        return vdb
+
+    def doc_details(self, results):
+        """
+        convert result into sources dict
+        """
+        sources = []
+        for source in results:
+            sources.append({"source": source[0].metadata["source"], "score": source[1]})
+        return sources
+
+    def search_documents(self, question):
+        """
+        Create summary answer for question
+        """
+        results = [
+            result for result in self.vdb.similarity_search_with_score(
+                question, k=settings.SEARCH_MAX_DOCUMENTS
+            ) if result[1] < settings.SEARCH_DISTANCE_THRESHOLD
+        ]
+        return {
+            "documents": self.doc_details(results)
+        }

--- a/integreat_chat/chatanswers/urls.py
+++ b/integreat_chat/chatanswers/urls.py
@@ -3,5 +3,7 @@ from . import views
 
 urlpatterns = [
     path("extract_answer/", views.extract_answer, name="extract_answer"),
+    path("search_documents/", views.search_documents, name="search_documents"),
+    path("translate_message/", views.translate_message, name="translate_message"),
     path("update_vdb/", views.update_vdb, name="update_vdb")
 ]

--- a/integreat_chat/chatanswers/views.py
+++ b/integreat_chat/chatanswers/views.py
@@ -54,12 +54,21 @@ def translate_message(request):
     if request.method in ('POST') and request.META.get('CONTENT_TYPE').lower() == 'application/json':
         data = json.loads(request.body)
         language_service = LanguageService()
-
-        result =  language_service.translate_message(
+        if ("source_language" not in data or
+            "target_language" not in data or
+            "message" not in data
+            ):
+            result = {"status":"error"}
+        else:
+            result = {
+                "translation": language_service.translate_message(
                     data["source_language"],
                     data["target_language"],
                     data["message"]
-                )
+                ),
+                "target_language": data["target_language"],
+                "status": "success"
+            }
     return JsonResponse(result)
 
 @csrf_exempt

--- a/integreat_chat/chatanswers/views.py
+++ b/integreat_chat/chatanswers/views.py
@@ -12,7 +12,6 @@ from integreat_chat.chatanswers.services.search import SearchService
 from .services.milvus import UpdateMilvus
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.conf import settings
 
 LOGGER = logging.getLogger('django')
 

--- a/integreat_chat/chatanswers/views.py
+++ b/integreat_chat/chatanswers/views.py
@@ -86,13 +86,17 @@ def extract_answer(request):
     result = None
     if request.method in ('POST') and request.META.get('CONTENT_TYPE').lower() == 'application/json':
         data = json.loads(request.body)
-        question = data["message"]
-        language = data["language"]
-        region = data["region"]
-        answer_service = AnswerService(region, language)
-        result = { "answer": "" }
-        if answer_service.needs_answer(question):
-            result = answer_service.extract_answer(question)
+        if ("language" not in data or
+            "region" not in data or
+            "message" not in data
+            ):
+            result = {"status":"error"}
+        else:
+            answer_service = AnswerService(data["region"], data["language"])
+            result = {}
+            if answer_service.needs_answer(data["message"]):
+                result = answer_service.extract_answer(data["message"])
+            result["status"] = "success"
     return JsonResponse(result)
 
 @csrf_exempt

--- a/integreat_chat/chatanswers/views.py
+++ b/integreat_chat/chatanswers/views.py
@@ -26,23 +26,30 @@ def search_documents(request):
     result = None
     if request.method in ('POST') and request.META.get('CONTENT_TYPE').lower() == 'application/json':
         data = json.loads(request.body)
-        language_service = LanguageService()
-        search_service = SearchService(data["region"], data["language"])
-        if language := language_service.classify_language(data["language"], data["message"]) == data["language"]:
-            result = {
-                "related_documents": search_service.search_documents(data["message"]),
-                "search_term": data["message"]
-            }
+        if ("language" not in data or
+            "message" not in data
+        ):
+            result = {"status":"error"}
         else:
-            translated_message = language_service.translate_message(
-                language,
-                data["language"],
-                data["message"]
-            )
-            result = {
-                "related_documents": search_service.search_documents(translated_message),
-                "search_term": translated_message
-            }
+            language_service = LanguageService()
+            search_service = SearchService(data["region"], data["language"])
+            if language := language_service.classify_language(data["language"], data["message"]) == data["language"]:
+                result = {
+                    "related_documents": search_service.search_documents(data["message"]),
+                    "search_term": data["message"],
+                    "status": "success"
+                }
+            else:
+                translated_message = language_service.translate_message(
+                    language,
+                    data["language"],
+                    data["message"]
+                )
+                result = {
+                    "related_documents": search_service.search_documents(translated_message),
+                    "search_term": translated_message,
+                    "status": "success"
+                }
     return JsonResponse(result)
 
 @csrf_exempt

--- a/integreat_chat/chatanswers/views.py
+++ b/integreat_chat/chatanswers/views.py
@@ -6,6 +6,8 @@ import json
 import logging
 
 from integreat_chat.chatanswers.services.answer_service import AnswerService
+from integreat_chat.chatanswers.services.language import LanguageService
+from integreat_chat.chatanswers.services.search import SearchService
 
 from .services.milvus import UpdateMilvus
 from django.http import JsonResponse
@@ -13,6 +15,52 @@ from django.views.decorators.csrf import csrf_exempt
 from django.conf import settings
 
 LOGGER = logging.getLogger('django')
+
+@csrf_exempt
+def search_documents(request):
+    """
+    Search for documents related to the question. If the message is in the wrong language,
+    first translate it to the GUI language. As we are only searching for similar documents,
+    this should be fine, even if the translation is not very good.
+    """
+    result = None
+    if request.method in ('POST') and request.META.get('CONTENT_TYPE').lower() == 'application/json':
+        data = json.loads(request.body)
+        language_service = LanguageService()
+        search_service = SearchService(data["region"], data["language"])
+        if language := language_service.classify_language(data["language"], data["message"]) == data["language"]:
+            result = {
+                "related_documents": search_service.search_documents(data["message"]),
+                "search_term": data["message"]
+            }
+        else:
+            translated_message = language_service.translate_message(
+                language,
+                data["language"],
+                data["message"]
+            )
+            result = {
+                "related_documents": search_service.search_documents(translated_message),
+                "search_term": translated_message
+            }
+    return JsonResponse(result)
+
+@csrf_exempt
+def translate_message(request):
+    """
+    Translate a message from a source into a target language
+    """
+    result = None
+    if request.method in ('POST') and request.META.get('CONTENT_TYPE').lower() == 'application/json':
+        data = json.loads(request.body)
+        language_service = LanguageService()
+
+        result =  language_service.translate_message(
+                    data["source_language"],
+                    data["target_language"],
+                    data["message"]
+                )
+    return JsonResponse(result)
 
 @csrf_exempt
 def extract_answer(request):

--- a/integreat_chat/core/settings.py
+++ b/integreat_chat/core/settings.py
@@ -11,9 +11,6 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
 from pathlib import Path
-import logging.handlers
-
-from integreat_chat.chatanswers.services.answer_service import AnswerService
 
 from langsmith import Client
 from langchain_huggingface import HuggingFaceEmbeddings
@@ -54,11 +51,24 @@ DEBUG = True
 ALLOWED_HOSTS = ["127.0.0.1", "igchat-inference.tuerantuer.org"]
 
 # Configuration Variables for answer service
-MODEL_LLM = "llama3.1:8b"
+QUESTION_CLASSIFICATION_MODEL = "llama3.2:3b"
+
+LANGUAGE_CLASSIFICATIONH_MODEL = "llama3.2:3b"
+
+TRANSLATION_MODEL = "llama3.1:8b"
+
+RAG_DISTANCE_THRESHOLD = 1.3
+RAG_MAX_DOCUMENTS = 3
+RAG_MODEL = "llama3.1:8b"
+RAG_PROMPT = Client().pull_prompt("rlm/rag-prompt")
+
+SEARCH_MAX_DOCUMENTS = 5
+SEARCH_DISTANCE_THRESHOLD = 1.5
+
 MODEL_EMBEDDINGS = "all-MiniLM-L6-v2"
 VDB_HOST = "127.0.0.1"
 VDB_PORT = "19530"
-PROMPT = Client().pull_prompt("rlm/rag-prompt")
+
 EMBEDDINGS = HuggingFaceEmbeddings(model_name=MODEL_EMBEDDINGS, show_progress=False)
 
 OLLAMA_BASE_PATH="http://10.137.0.1:11434"


### PR DESCRIPTION
Add API endpoints for searching documents and translating messages.

The search endpoint checks first if a message is in the expected language. If it is not, it is first translated and the translation is used for searching related documents.

Fix #37 & #12 