### PR TITLE
Add limit for max context length

### DIFF
--- a/integreat_chat/chatanswers/services/answer_service.py
+++ b/integreat_chat/chatanswers/services/answer_service.py
@@ -74,7 +74,7 @@ class AnswerService:
 
         context = RunnableLambda(lambda _: "\n".join(
             [result['text'] for result in results]
-        ))
+        )[:settings.RAG_CONTEXT_MAX_LENGTH])
         if not results:
             language_service = LanguageService()
             return {

--- a/integreat_chat/core/settings.py
+++ b/integreat_chat/core/settings.py
@@ -65,6 +65,7 @@ RAG_PROMPT = Client().pull_prompt("rlm/rag-prompt")
 RAG_RELEVANCE_CHECK = True
 RAG_QUERY_OPTIMIZATION = True
 RAG_QUERY_OPTIMIZATION_MODEL = "llama3.1:70b"
+RAG_CONTEXT_MAX_LENGTH = 8000
 
 # SEARCH_MAX_DOCUMENTS - number of documents retrieved from the VDB
 SEARCH_MAX_DOCUMENTS = 15


### PR DESCRIPTION
It seems that too much context currently does not work well. We should limit the context. 8000 characters seems to work with the 70B model.

This also seems to fix #88 