### PR TITLE
Force lang usage in answer generation prompt

### DIFF
--- a/integreat_chat/chatanswers/services/answer_service.py
+++ b/integreat_chat/chatanswers/services/answer_service.py
@@ -105,7 +105,7 @@ class AnswerService:
                 )
             }
         rag_chain = (
-            {"context": context, "question": RunnablePassthrough()}
+                {"language": self.language, "context": context, "question": RunnablePassthrough()}
                 | settings.RAG_PROMPT
                 | self.llm
                 | StrOutputParser()

--- a/integreat_chat/chatanswers/static/prompts.py
+++ b/integreat_chat/chatanswers/static/prompts.py
@@ -11,7 +11,7 @@ class Prompts:
     RAG = """You are an assistant for question-answering tasks.
 Use the following pieces of retrieved context to answer the question.
 If you don't know the answer, just say that you don't know.
-Use three sentences maximum and keep the answer concise.
+Use three sentences maximum and keep the answer concise. Answer the question in {language} language.
 
 Question: {question}
 


### PR DESCRIPTION
I was looking into whether having the prompts themselves in different languages is beneficial to generate a better response for the LLM. I don't have an answer to that yet

However, I found the same opinion a few times on the internet claiming that adding the target language to the prompt itself would be a good solution