### PR TITLE
Allow configuring log level in config

### DIFF
--- a/integreat-chat.ini
+++ b/integreat-chat.ini
@@ -1,3 +1,6 @@
+[DEFAULT]
+LOG_LEVEL = INFO
+
 [LiteLLM]
 SERVER=https://localhost:8000
 API_KEY=changeme

--- a/integreat_chat/core/settings.py
+++ b/integreat_chat/core/settings.py
@@ -49,7 +49,7 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['apache'],
-            'level': 'DEBUG' if DEBUG else 'INFO',
+            'level': 'DEBUG' if DEBUG else config["DEFAULT"]["LOG_LEVEL"],
             'propagate': True,
         },
     },

--- a/integreat_chat/core/settings.py
+++ b/integreat_chat/core/settings.py
@@ -41,7 +41,7 @@ LOGGING = {
     'disable_existing_loggers': False,
     'handlers': {
         'apache': {
-            'level': 'DEBUG' if DEBUG else 'INFO',
+            'level': 'DEBUG' if DEBUG else config["DEFAULT"]["LOG_LEVEL"],
             'class': 'logging.StreamHandler',
             'stream': 'ext://sys.stderr',  # Logs to Apache's error log
         },


### PR DESCRIPTION
The log level should be configurable without setting the Django application to debug mode.