### PR TITLE
Use X-Integreat-Development header

### DIFF
--- a/integreat_chat/core/utils/integreat_cms.py
+++ b/integreat_chat/core/utils/integreat_cms.py
@@ -1,19 +1,18 @@
 """
 Integreat CMS helper functions
 """
-import json
-from urllib.request import urlopen
 from urllib.parse import quote
 
+import requests
 from django.conf import settings
 
 def get_region_languages(region: str) -> list[str]:
     """
     get all language slugs of a given region
     """
-    path = f"https://{settings.INTEGREAT_CMS_DOMAIN}/api/v3/{region}/languages/"
-    with urlopen(path) as response:
-        languages = json.loads(response.read())
+    url = f"https://{settings.INTEGREAT_CMS_DOMAIN}/api/v3/{region}/languages/"
+    headers = {"X-Integreat-Development": "true"}
+    languages = requests.get(url, timeout=15, headers=headers).json()
     return [language["code"] for language in languages]
 
 def get_page(path: str) -> dict:
@@ -27,10 +26,10 @@ def get_page(path: str) -> dict:
     )
     region = path.split("/")[1]
     cur_language = path.split("/")[2]
+    headers = {"X-Integreat-Development": "true"}
     pages_url = (
         f"https://{settings.INTEGREAT_CMS_DOMAIN}/api/v3/{region}/"
         f"{cur_language}/children/?url={path}&depth=0"
     )
     encoded_url = quote(pages_url, safe=':/=?&')
-    with urlopen(encoded_url) as response:
-        return json.loads(response.read())[0]
+    return requests.get(encoded_url, timeout=15, headers=headers).json()[0]


### PR DESCRIPTION
Set the [`X-Integreat-Development` header](https://digitalfabrik.github.io/integreat-cms/api-docs.html#sending-the-development-header) to hide requests in statistics.