### PR TITLE
Differential page indexing

### DIFF
--- a/integreat_chat/search/management/commands/index_all_regions.py
+++ b/integreat_chat/search/management/commands/index_all_regions.py
@@ -14,10 +14,17 @@ class Command(BaseCommand):
     """
     help = "Index pages for all configured regions"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--full",
+            action="store_true",
+            help="Re-create full index",
+        )
+
     def handle(self, *args, **options):
         for region_slug in settings.INTEGREAT_REGIONS:
             for language_slug in get_region_languages(region_slug):
-                update_index.apply_async([region_slug, language_slug])
+                update_index.apply_async([region_slug, language_slug, not options["full"]])
                 self.stdout.write(self.style.SUCCESS(  # pylint: disable=no-member
                     f"Queued indexing pages for region {region_slug} and language {language_slug}"
                 ))

--- a/integreat_chat/search/management/commands/index_pages.py
+++ b/integreat_chat/search/management/commands/index_pages.py
@@ -15,13 +15,18 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("region", type=str)
         parser.add_argument("language", type=str)
+        parser.add_argument(
+            "--full",
+            action="store_true",
+            help="Re-create full index",
+        )
 
     def handle(self, *args, **options):
         if "region" not in options or "language" not in options:
             raise CommandError('missing region or language argument')
         region_slug = options["region"]
         language_slug = options["language"]
-        update_index.apply_async([region_slug, language_slug])
+        update_index.apply_async([region_slug, language_slug, not options["full"]])
         self.stdout.write(self.style.SUCCESS(  # pylint: disable=no-member
             f"Queued indexing pages for region {region_slug} and language {language_slug}"
         ))

--- a/integreat_chat/search/management/commands/index_region.py
+++ b/integreat_chat/search/management/commands/index_region.py
@@ -16,13 +16,18 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("region", type=str)
+        parser.add_argument(
+            "--full",
+            action="store_true",
+            help="Re-create full index",
+        )
 
     def handle(self, *args, **options):
         if "region" not in options:
             raise CommandError('missing region argument')
         region_slug = options["region"]
         for language_slug in get_region_languages(region_slug):
-            update_index.apply_async([region_slug, language_slug])
+            update_index.apply_async([region_slug, language_slug, not options["full"]])
             self.stdout.write(self.style.SUCCESS(  # pylint: disable=no-member
                 f"Queued indexing pages for region {region_slug} and language {language_slug}"
             ))

--- a/integreat_chat/search/tasks.py
+++ b/integreat_chat/search/tasks.py
@@ -7,16 +7,17 @@ from integreat_chat.core.utils.integreat_cms import get_region_languages
 
 
 @shared_task
-def update_index(region_slug: str, language_slug: str) -> None:
+def update_index(region_slug: str, language_slug: str, differential: bool = True) -> None:
     """
     param region_slug: slug of the region which should be updated
     param language_slug: slug of the language (BCP47 tag) that should be updated
     """
     oss = OpenSearchSetup(password=settings.OPENSEARCH_PASSWORD)
     print(f"Indexing pages for region {region_slug} and language {language_slug}")
-    print(oss.delete_index(f"{region_slug}_{language_slug}"))
-    print(oss.create_index(f"{region_slug}_{language_slug}"))
-    oss.index_pages(region_slug, language_slug)
+    if not differential:
+        print(oss.delete_index(f"{region_slug}_{language_slug}"))
+        print(oss.create_index(f"{region_slug}_{language_slug}"))
+    oss.index_pages(region_slug, language_slug, differential)
 
 
 @shared_task


### PR DESCRIPTION
This PR introduces differential updates of OpenSearch indexes. When calling an index update via the management commands, only pages that changed in the last 7 days will be re-inserted into the index. When adding the `--full` flag, all pages will be re-indexed.

Additionally, the md5sum of a text chunk is stored in the database to detect duplicate chunks across different indexing runs.

Fix #248