### PR TITLE
Fix removing old chunks from index

### DIFF
--- a/integreat_chat/search/services/opensearch.py
+++ b/integreat_chat/search/services/opensearch.py
@@ -183,7 +183,7 @@ class OpenSearch:
         payload = {
             "query": {
                 "match": {
-                    "md5sum": page_id
+                    "id": page_id
                 }
             }
         }


### PR DESCRIPTION
We need to remove old chunks by ID (which was intended anyways), not md5sum.

Fix #265