### PR TITLE
Improve handling of unrelated documents

### DIFF
--- a/integreat_chat/chatanswers/services/answer.py
+++ b/integreat_chat/chatanswers/services/answer.py
@@ -121,14 +121,16 @@ class AnswerService:
             ]
         )[: settings.RAG_CONTEXT_MAX_LENGTH]
 
-        if not documents:
-            return RagResponse(
+        no_answer = RagResponse(
                 documents,
                 self.rag_request,
                 language_service.translate_message(
                     "en", self.language, Messages.NO_ANSWER
                 ),
             )
+
+        if not documents:
+            return no_answer
         LOGGER.debug("Generating answer.")
         answer = self.llm_api.simple_prompt(
             Prompts.RAG.format(self.language, self.rag_request.search_term, context)
@@ -138,6 +140,8 @@ class AnswerService:
             self.rag_request.search_term,
             answer
         )
+        if answer == "":
+            return no_answer
         return RagResponse(documents, self.rag_request, answer)
 
     async def check_documents_relevance(self, question: str, search_results: list) -> bool:
@@ -148,18 +152,18 @@ class AnswerService:
         param content: a page content that could be relevant for answering the question
         return: bool that indicates if the page is relevant for the question
         """
-        sys_message = LlmMessage(Prompts.CHECK_SYSTEM_PROMPT, "system")
         tasks = []
         async with aiohttp.ClientSession() as session:
             for document in search_results:
-                message = LlmMessage(Prompts.RELEVANCE_CHECK.format(
-                    question,
-                    f"# {document.parent_titles}\n\n{document.content}"
-                ))
                 tasks.append(
                     asyncio.create_task(self.llm_api.chat_prompt(
                         session,
-                        LlmPrompt(settings.RAG_RELEVANCE_CHECK_MODEL, [sys_message, message])
+                        LlmPrompt(settings.RAG_RELEVANCE_CHECK_MODEL, [
+                            LlmMessage(Prompts.CHECK_SYSTEM_PROMPT.format(
+                                f"## {document.parent_titles}\n\n{document.content}"
+                            ), "system"),
+                            LlmMessage(question)]
+                        )
                     )
                 ))
             llmresponses = await asyncio.gather(*tasks)

--- a/integreat_chat/chatanswers/services/answer.py
+++ b/integreat_chat/chatanswers/services/answer.py
@@ -94,7 +94,7 @@ class AnswerService:
         LOGGER.debug("Number of retrieved documents: %i", len(search_results))
         if settings.RAG_RELEVANCE_CHECK:
             search_results = asyncio.run(self.check_documents_relevance(
-                str(self.rag_request), search_results)
+                str(self.rag_request.search_term), search_results)
             )
             LOGGER.debug("Number of documents after relevance check: %i", len(search_results))
         return search_results[:settings.RAG_MAX_PAGES]

--- a/integreat_chat/chatanswers/static/prompts.py
+++ b/integreat_chat/chatanswers/static/prompts.py
@@ -21,17 +21,23 @@ User message: {1}
 Linked pages: {2}
 """
 
-    CHECK_SYSTEM_PROMPT = "You are an internal assistant in an application without user interaction."
+    CHECK_SYSTEM_PROMPT = """# Task
+You are part of a retrieval-augmented generation (RAG) system. Your task is to evaluate whether a retrieved document definitely contains a direct answer to the user’s message.
+Evaluation Criteria:
 
-    RELEVANCE_CHECK = """You are part of a retrieval augmented generation system.
-It's your task to filter retrieved documents that can be used to answer the user question.
-Provide a binary judgement if the document contains an answer to the user question, responding with either 'yes' or 'no'.
+* The document must explicitly address the user’s question or request.
+* General relevance is not enough — it must contain specific and authoritative information.
+* If the document only provides related background information but does not directly answer the question, answer "no".
+* If the document contains the exact answer or directly relevant information, answer "yes".
 
-User question: {0}
+Response Format:
 
-Retrieved document:
-{1}
-"""
+* Answer only with "yes" or "no"—no explanations or additional text.
+
+# Retrieved document:
+
+{0}"""
+
 
     CHECK_QUESTION = """### Task
 You are part of a retrieval-augmented generation system. Determine whether the **last message in a conversation** requires a response.


### PR DESCRIPTION
Improve document relevance prompt. It should now more often reject documents.

Refactor the actual RAG prompt so that it could in theory provide an empty response (prompting the LLM to return empty responses if it cannot provide an answer does not work).