### PR TITLE
Improve translation prompt

### DIFF
--- a/integreat_chat/translate/static/prompts.py
+++ b/integreat_chat/translate/static/prompts.py
@@ -28,4 +28,4 @@ If a few German nouns are mixed into the message, ignore them.
         "strict": True,
     }
 
-    TRANSLATE_PROMPT = "You are a translator. Source and target languages are given as BCP-47 tags. Translate the user message from {0} into {1}. Return nothing else than the translation itself."
+    TRANSLATE_PROMPT = "Translate the following text from '{0}' to '{1}' using BCP-47 language tags. Provide only the translation, without any additional text or explanation."


### PR DESCRIPTION
More robust translation prompt.

Fix #290

Worked in 10 out of 10 tests.