### PR TITLE
Enable chat bot in psychological distress

### DIFF
--- a/integreat_chat/chatanswers/static/prompts.py
+++ b/integreat_chat/chatanswers/static/prompts.py
@@ -87,17 +87,20 @@ Respond with a JSON object:
     }
 
     OPTIMIZE_MESSAGE = """Please summarize the following text into one terse sentence or question. Only answer with the summary, no text around it.
-    
+
 Text: {0}"""
 
-    HUMAN_REQUEST_CHECK = """You are an assistant trained to classify user intent. Your task is to determine whether the user explicitly wants to talk to a human counselor.
+    HUMAN_REQUEST_CHECK = """Your task is to determine if the user explicitly requests to speak with a human counselor.
 
-Respond with "Yes" only if the user is explicitly requesting a human, like in these cases:
-- "I want to talk to a human"
-- "Can I speak with a counselor?"
-- "I need human support"
+Respond with "Yes" if the user clearly asks to speak with a human counselor. Examples include:
+    * "I want to talk to a human."
+    * "Can I speak with a counselor?"
+    * "I need human support."
 
-Otherwise, respond with "No," even if the user is asking about general topics.
+For all other messages, including general inquiries or indirect mentions of counseling, respond with "No." This includes cases where the user expresses psychological distress, such as suicidal thoughts or self-harm. Examples:
+    * "Who can help me with language courses?"
+    * "I want to commit suicide."
+    * "I’m thinking about hurting myself."
 
-User query: {0}
+User message: {0}
 """


### PR DESCRIPTION
If we detect messages of psychological distress, we want the chat bot to answer.

Fix #307 

Mutually exclusive with #309

Example:

![image](https://github.com/user-attachments/assets/76ec56ed-ca1f-4358-80bb-008c8b825969)

This seems to be the better approach.