### PR TITLE
Use asyncio for CMS requests

### DIFF
--- a/integreat_chat/core/utils/integreat_cms.py
+++ b/integreat_chat/core/utils/integreat_cms.py
@@ -1,9 +1,11 @@
 """
 Integreat CMS helper functions
 """
+import asyncio
 from urllib.parse import quote
 
 import requests
+import aiohttp
 from django.conf import settings
 
 def get_region_languages(region: str) -> list[str]:
@@ -34,7 +36,35 @@ def get_page(path: str) -> dict:
     encoded_url = quote(pages_url, safe=':/=?&')
     return requests.get(encoded_url, timeout=15, headers=headers).json()[0]
 
-def get_pages(region_slug: str, language_slug: str) -> list[dict]:
+async def fetch_single_page(session: aiohttp.ClientSession, path: str) -> dict:
+    """
+    get page object for RAG source
+    """
+    path = (
+        path
+        .replace(f"https://{settings.INTEGREAT_APP_DOMAIN}", "")
+        .replace(f"https://{settings.INTEGREAT_CMS_DOMAIN}", "")
+    )
+    region = path.split("/")[1]
+    cur_language = path.split("/")[2]
+    headers = {"X-Integreat-Development": "true"}
+    pages_url = (
+        f"https://{settings.INTEGREAT_CMS_DOMAIN}/api/v3/{region}/"
+        f"{cur_language}/children/?url={path}&depth=0"
+    )
+    encoded_url = quote(pages_url, safe=':/=?&')
+    async with session.get(encoded_url, timeout=15, headers=headers) as response:
+        return (await response.json())[0]
+
+async def get_multiple_pages(paths: list[str]) -> list[dict]:
+    """
+    get page objects for RAG source in parallel
+    """
+    async with aiohttp.ClientSession() as session:
+        tasks = [fetch_single_page(session, path) for path in paths]
+        return await asyncio.gather(*tasks)
+
+def get_all_pages(region_slug: str, language_slug: str) -> list[dict]:
     """
     get data from Integreat cms
     """

--- a/integreat_chat/search/services/opensearch.py
+++ b/integreat_chat/search/services/opensearch.py
@@ -9,7 +9,7 @@ from datetime import timedelta, datetime
 import requests
 from django.conf import settings
 from langchain_text_splitters import HTMLHeaderTextSplitter
-from integreat_chat.core.utils.integreat_cms import get_pages, get_parent_page_titles
+from integreat_chat.core.utils.integreat_cms import get_all_pages, get_parent_page_titles
 
 class OpenSearch:
     """
@@ -268,7 +268,7 @@ class OpenSearch:
         :param language_slug: Integreat CMS language slug
         :param differential: recreate (fill) index if false, update if true
         """
-        cms_pages = get_pages(region_slug, language_slug)
+        cms_pages = get_all_pages(region_slug, language_slug)
         if differential:
             self.remove_deleted_pages(
                 f"{region_slug}_{language_slug}",

--- a/integreat_chat/search/services/search.py
+++ b/integreat_chat/search/services/search.py
@@ -1,6 +1,7 @@
 """
 A service to search for documents
 """
+import aiohttp
 from django.conf import settings
 
 from .opensearch import OpenSearch
@@ -40,13 +41,15 @@ class SearchService:
             min_score = min_score,
         )
         documents = []
-        for result in results:
-            documents.append(Document(
-                result["url"],
-                result["chunk_text"],
-                result["score"],
-                result["parent_titles"],
-                include_text,
-                self.search_request.gui_language,
-            ))
+        async with aiohttp.ClientSession() as session:
+            for result in results:
+                documents.append(Document.create(
+                    result["url"],
+                    result["chunk_text"],
+                    result["score"],
+                    result["parent_titles"],
+                    include_text,
+                    self.search_request.gui_language,
+                    session
+                ))
         return SearchResponse(self.search_request, documents)

--- a/integreat_chat/search/utils/search_response.py
+++ b/integreat_chat/search/utils/search_response.py
@@ -1,6 +1,7 @@
 """
 responses to search request and document class
 """
+import asyncio
 import logging
 import urllib
 
@@ -21,7 +22,6 @@ class Document:
             chunk: str,
             score: float,
             parent_titles: list[str],
-            include_details: bool,
             gui_language: str
         ):
         self.chunk_source_path = source_path
@@ -29,9 +29,22 @@ class Document:
         self.score = score
         self.chunk = chunk
         self.parent_titles = parent_titles
-        self.enrich(include_details)
+        self.gui_source_path = None
+        self.title = None
+        self.content = None
 
-    def enrich(self, include_details: bool):
+    async def create_with_details(self,
+            source_path: str,
+            chunk: str,
+            score: float,
+            parent_titles: list[str],
+            gui_language: str,
+            aiohttp_client
+        ):
+        self.__init__(source_path, chunk, score, parent_titles, gui_language)
+        asyncio.run(self.enrich(True))
+    
+    async def enrich(self, include_details: bool):
         """
         Enrich document with GUI langauge URLs and titles
         """


### PR DESCRIPTION
One (still incomplete) approach to implement async requests to the Intgreat CMS.

However, I don't like the approach of creating the objects with async functions. It could be better to retrieve all data from the CMS before and just pass the responses into the objects. That would introduce less complexity.

Fix #324 