### PR TITLE
Ignore missing parent titles when indexing

### DIFF
--- a/integreat_chat/search/services/opensearch.py
+++ b/integreat_chat/search/services/opensearch.py
@@ -304,7 +304,10 @@ class OpenSearch:
         page_path = page["path"]
         parent_titles = []
         for parent in get_parent_page_titles(region_slug, language_slug, page_path):
-            parent_titles.append(parent["title"])
+            try:
+                parent_titles.append(parent["title"])
+            except TypeError:
+                pass
         return parent_titles
 
 class OpenSearchSetup(OpenSearch):


### PR DESCRIPTION
When `get_parent_title` returns an error for specific parents, we should ignore the error and continue with the next page.