### PR TITLE
Preflight context check

### DIFF
--- a/integreat_chat/chatanswers/static/prompts.py
+++ b/integreat_chat/chatanswers/static/prompts.py
@@ -129,3 +129,8 @@ You are part of a retrieval-augmented generation (RAG) system. In a previous sea
 ## Search Term
 {1}
 """
+
+    CONTEXT_CHECK = """You're a compontent of a RAG system tasked with answering questions. Your job is to judge if a message contains an answerable question or if context from previous messages is required. Answer only with "yes", if more context is required and "no" if the message itself can be answered.
+
+User message: {0}
+"""


### PR DESCRIPTION
We currently have few conversations were sentences are split across multiple messages. On the other hand we have many chats were questions about multiple topics are asked. I think this provides a balanced approach to avoid Llama 3.3 mixing topics.