### PR TITLE
Reduce context to previous message

### DIFF
--- a/integreat_chat/chatanswers/services/answer.py
+++ b/integreat_chat/chatanswers/services/answer.py
@@ -124,7 +124,7 @@ class AnswerService:
         :param message: a user message
         :return: answer message if no further processing is required, else False
         """
-        num_messages = 3 if self.message_requires_context() else 1
+        num_messages = settings.RAG_CONTEXT_LENGTH if self.message_requires_context() else 1
         LOGGER.debug("Using the last %s messages.", num_messages)
         request_human, summary, accept_message = asyncio.run(
             self.check_message_parallelized(num_messages)

--- a/integreat_chat/core/settings.py
+++ b/integreat_chat/core/settings.py
@@ -96,6 +96,7 @@ RAG_QUERY_OPTIMIZATION_MODEL = "llama3.3"
 RAG_CONTEXT_MAX_LENGTH = 8000
 RAG_SUPPORTED_LANGUAGES = ["en", "de"]
 RAG_FALLBACK_LANGUAGE = "en"
+RAG_CONTEXT_LENGTH = 2 # Number of messages passed to LLM if the last message requires context
 
 # Limit number of messages processed. The last N messages will be used.
 REQUEST_MAX_MESSAGES = 10


### PR DESCRIPTION
I could not find a real chat were the context of the last 3 messages was necessary. However, Llama 3.3 still mixed topics if context for the last message is required by the previous 2 are about different topics. Therefore it seems reasonable to reduce the context to 1 message for the time being.