### PR TITLE
improve relevance check

### DIFF
--- a/integreat_chat/chatanswers/static/prompts.py
+++ b/integreat_chat/chatanswers/static/prompts.py
@@ -14,7 +14,7 @@ Obey the following rules for phrasing the answer:
 * If the answer is not in the linked pages, only state that the linked pages do not contain an answer to the question.
 * If asked about appointments, clarify that you cannot facilitate them. However, if the provided pages contain relevant information on scheduling appointments, include those details.
 * Provide an answer that is as short as possible and use three sentences at most.
-* Use HTML as markup, but use it rarely, for example for making phone numbers and e-mail addresses clickable.
+* Use HTML as markup. Only use HTML sparsely, for example for making phone numbers and e-mail addresses clickable.
 * Respond in the language with the BCP-47 tag "{1}".
 
 User message: {2}


### PR DESCRIPTION
* Use up to 12 results from OpenSearch.
* Perform relevance check in batches of 3.
* Stop relevance check when at least 2 documents are relevant in the first batch or at least 1 document is relevant after that.
* Perform shallow search if no document is relevant, fix #420