### PR TITLE
Fix fetching broken CMS URLs

### DIFF
--- a/integreat_chat/core/utils/integreat_cms.py
+++ b/integreat_chat/core/utils/integreat_cms.py
@@ -2,11 +2,14 @@
 Integreat CMS helper functions
 """
 import asyncio
+import logging
 from urllib.parse import quote
 
 import aiohttp
 import requests
 from django.conf import settings
+
+LOGGER = logging.getLogger(__name__)
 
 def get_region_languages(region: str) -> list[str]:
     """
@@ -77,20 +80,21 @@ async def async_get_page(session: aiohttp.ClientSession, path: str, retry: int =
     ) as response:
         try:
             return (await response.json())[0]
-        except IndexError as exc:
+        except (IndexError, KeyError) as exc:
             if retry < 3:
                 return await async_get_page(session, path, retry=retry+1)
+            LOGGER.error("Could not fetch page from CMS: %s", path)
             raise ValueError(f"Could not fetch data for {path}") from exc
 
-async def cms_requests_session_wrapper(paths: list[str]) -> list[dict]:
+async def cms_requests_session_wrapper(paths: list[str]) -> list[dict | BaseException]:
     """
     Create an aiohttp session, send requests and gather responses
     """
     async with aiohttp.ClientSession() as session:
         tasks = [async_get_page(session, path) for path in paths]
-        return await asyncio.gather(*tasks)
+        return await asyncio.gather(*tasks, return_exceptions=True)
 
-def get_pages(paths: list[str]) -> list[dict]:
+def get_pages(paths: list[str]) -> list[dict | BaseException]:
     """
     Get content for multiple pages
     """

--- a/integreat_chat/search/services/search.py
+++ b/integreat_chat/search/services/search.py
@@ -1,6 +1,8 @@
 """
 A service to search for documents
 """
+import logging
+
 from django.conf import settings
 
 from core.utils.integreat_cms import get_pages
@@ -8,6 +10,8 @@ from core.utils.integreat_cms import get_pages
 from .opensearch import OpenSearch
 from ..utils.search_request import SearchRequest
 from ..utils.search_response import SearchResponse, Document
+
+LOGGER = logging.getLogger(__name__)
 
 class SearchService:
     """
@@ -41,13 +45,16 @@ class SearchService:
         )
         pages = get_pages([result["url"] for result in results])
         documents = []
-        for item_num, result in enumerate(results):
+        for result, page in zip(results, pages):
+            if isinstance(page, BaseException):
+                LOGGER.error("Skipping document, page could not be fetched: %s", result["url"])
+                continue
             documents.append(Document(
                 result["url"],
                 result["chunk_text"],
                 result["score"],
                 result["parent_titles"],
-                pages[item_num],
+                page,
                 self.search_request.gui_language,
             ))
         return SearchResponse(self.search_request, documents)


### PR DESCRIPTION
Catch error when fetching of page fails. This should usually not happen, but in tests were test and prod CMS contents are mixed, this at least yields usable test messages.